### PR TITLE
Added Metadata Plugin and documentation.

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -39,6 +39,34 @@
 
 **Example**: `(gh-pages :cname t)`
 
+## SEO and Social Metadata
+
+**Description**: Adds description and keywords metadata for SEO purposes.
+  Adds both Open Graph and Twitter Cards metadata for sharing posts as well.
+  `:twitter` keyword argument sets "site" property of Twitter.
+  Twitter Card specific metadata will be omitted if this property is not set.
+  `:card` keyword argument sets the type of Twitter card created.
+  Possible types are `:summary` and `:image`. Defaults to `:summary`.
+  
+  Five *optional* tags for post file header are added.
+
+  `keywords:` comma, seperated, seo, keywords.
+  They will be generated from tags if empty.
+
+  `description:` Description to be used in SEO and
+  Open Graph description tags. If empty, Open Graph description will be generated
+  from content while SEO description metadata will be omitted.
+
+  `image:` either an absolute (`http://www.example.com/image.png`)
+  or a root-relative (`/static/image.png`) image URL.
+
+  `card:` Overrides Twitter Card type defined in plugin activation.
+  Possible values are either `image` or `summary`.
+
+  `creator:` Twitter username of the content creator.
+
+**Example**: `(metadata :twitter "twitter_account" :card :summary)`
+
 ## Incremental Builds
 
 **Description**: Primarily a performance enhancement. Caches the

--- a/plugins/metadata.lisp
+++ b/plugins/metadata.lisp
@@ -1,0 +1,81 @@
+(eval-when (:compile-toplevel :load-toplevel)
+  (ql:quickload 's-xml))
+
+(defpackage :coleslaw-metadata
+  (:use :cl :coleslaw)
+  (:import-from :coleslaw
+                #:title
+                #:domain
+                #:tag-name
+                #:page-url
+                #:content-tags
+                #:content-text
+                #:keywords-of
+                #:description-of
+                #:image-of
+                #:card-format
+                #:creator-of)
+    (:import-from :s-xml
+                #:xml-parser-state
+                #:start-parse-xml)
+  (:export #:enable))
+
+(in-package :coleslaw-metadata)
+
+(defparameter *description-length* 200)
+
+(defvar *metadata-header*
+  "
+<meta name=\"keywords\" content=\"~A\" />~@[
+<meta name=\"description\" content=\"~A\" />~]~:[~*~*~;~:*
+<meta name=\"twitter:site\" content=\"@~A\" />
+<meta name=\"twitter:card\" content=\"~:[summary~;summary_large_image~]\" />~@[
+<meta name=\"twitter:creator\" content=\"@~A\" />~]~]
+<meta property=\"og:title\" content=\"~A\" />
+<meta property=\"og:site_name\" content=\"~A\" />
+<meta property=\"og:url\" content=\"~A\" />
+<meta property=\"og:description\" content=\"~A\" />~@[
+<meta property=\"og:image\" content=\"~A\" />~]
+")
+
+(defun remove-markup (text)
+  (with-input-from-string (in text)
+    (let* ((state (make-instance 'xml-parser-state
+                                 :text-hook #'(lambda (string seed) (cons string seed))))
+           (result (start-parse-xml in state)))
+      (apply #'concatenate 'string (nreverse result)))))
+
+(defun shorten-text (text)
+  (if (< *description-length* (length text))
+      (subseq text 0 (- *description-length* 1)) text))
+
+(defun compile-description (text)
+  (shorten-text (remove #\" (remove-markup text))))
+
+(defun root-relative-url-p (url)
+  (eq (elt url 0) #\/))
+
+(defun compile-url (url)
+  (if (root-relative-url-p url)
+      (concatenate 'string (domain *config*) url)
+      url))
+
+(defun compile-metadata (post twitter card)
+  (format nil *metadata-header*
+          (or (keywords-of post)
+              (format nil "~{~A~^, ~}" (mapcar #'tag-name (content-tags post))))
+          (description-of post)
+          twitter
+          (eq (or (card-format post) card) :image)
+          (creator-of post)
+          (title-of post)
+          (title *config*)
+          (concatenate 'string (domain *config*) "/" (namestring (page-url post)))
+          (or (description-of post)
+              (compile-description (content-text post)))
+          (when (image-of post) (compile-url (image-of post)))))
+
+(defun enable (&key twitter card)
+  (flet ((inject-p (x)
+           (when (typep x 'post) (compile-metadata x twitter card))))
+    (add-injection #'inject-p :head)))

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -3,15 +3,27 @@
 (defclass post (content)
   ((title  :initarg :title  :reader title-of)
    (author :initarg :author :reader author-of)
-   (format :initarg :format :reader post-format))
-  (:default-initargs :author nil))
+   (format :initarg :format :reader post-format)
+   (keywords :initarg :keywords :reader keywords-of)
+   (description :initarg :description :reader description-of)
+   (image :initarg :image :reader image-of)
+   (card :initarg :card :reader card-format)
+   (creator :initarg :creator :reader creator-of))
+  (:default-initargs
+   :author nil
+   :keywords nil
+   :description nil
+   :image nil
+   :card nil
+   :creator nil))
 
 (defmethod initialize-instance :after ((object post) &key)
-  (with-slots (url title author format text) object
+  (with-slots (url title author format card text) object
     (setf url (compute-url object (slugify title))
           format (make-keyword (string-upcase format))
           text (render-text text format)
-          author (or author (author *config*)))))
+          author (or author (author *config*))
+          card (if card (make-keyword (string-upcase card))))))
 
 (defmethod render ((object post) &key prev next)
   (funcall (theme-fn 'post) (list :config *config*


### PR DESCRIPTION
The Metadata Plugin adds SEO metadata, Open Graph metadata (the metadata most social platforms including Facebook use) and Twitter Cards specific metadata. The documentation is provided. So far I tested it with many different combinations of header data and keyword argument combinations. They all worked as intended.

Some notes on implementation:

The plugin activation needs to keyword arguments:
`:twitter` keyword argument sets "site" property of Twitter. (That is the Twitter account the Card is going to be bound to.)
  Twitter Card specific metadata will be omitted if this property is not set because this option is mandatory.
`:card` keyword argument sets the type of Twitter card created.
  Possible types are `:summary` and `:image`. Defaults to `:summary`.

The og:url property doesn't currently seem essential in coleslaw because a post has only one address. og:url (or twitter:url which defaults to og:url actually) is important when there are multiple url's to same post. But I added it as well just to make sure it is there when it becomes important.
I've seen your comment about twitter:url on twitter-summary-cards plugin which made me think if there is a pitfall to the seemingly obvious approach to getting the url. I would be happy to check my method and inform me if I am doing something wrong here: `(concatenate 'string (domain *config*) "/" (namestring (page-url post)))`

As with the twitter:url, some other properties like twitter:description are intentionally omitted, because those default to Open Graph tags that are already provided, which prevents duplication.

The description for Open Graph metadata is created from post content if not explicitly stated in post header because some platforms make it mandatory. But it is omitted from SEO description when not stated by user. Because Google is does a better job of crawling description strings from content than me. :) And also it is better SEO practice to not provide a description tag at all than coming up with a possible bad one. The content is stripped of markup tags and quotation marks first before added to metadata because Facebook doesn't hide tags when they explicitly exist in the description and quotations in the description break HTML file.

The SEO keywords are created from tags when they are not explicitly stated in post header.

The image to be used in sharing is either and absolute URL or a root-relative URL like `/static/image.png`

This plugin also makes the `twitter-summary-card` plugin unnecessary because it handles both `summary card` and `summary card with large image` types but you might want to keep it around in case it is already in people's configurations.