### PR TITLE
Supporting other file extensions for the index page as well.

### DIFF
--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -36,7 +36,8 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
       (publish ctype))
     (do-subclasses (itype index)
       (publish itype))
-    (update-symlink "index.html" "1.html")))
+    (update-symlink (format nil "index.~A" (page-ext *config*))
+                    (format nil "1.~A" (page-ext *config*)))))
 
 (defgeneric deploy (staging)
   (:documentation "Deploy the STAGING build to the directory specified in the config.")


### PR DESCRIPTION
Coleslaw is able to write the blog content to xhtml file as well, using the
configuration setting :page-ext. But it did ignore the file extension when
creating the index page link responsible for the default landing page. With this
fix the file extension gets honored. E.g. when "xhtml" is configured, coleslaw
will generate a link from "index.xhtml" to "1.xhtml".