### PR TITLE
Improve routing

### DIFF
--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -37,8 +37,9 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
       (publish ctype))
     (do-subclasses (itype index)
       (publish itype))
-    (update-symlink (blog-index *config*)
-                    (format nil "1.~A" (page-ext *config*)))))
+    (when (blog-index *config*)
+      (update-symlink (blog-index *config*)
+                      (get-first-numeric-index)))))
 
 (defgeneric deploy (staging)
   (:documentation "Deploy the STAGING build to the directory specified in the config.")

--- a/src/coleslaw.lisp
+++ b/src/coleslaw.lisp
@@ -37,7 +37,7 @@ in REPO-DIR. Optionally, OLDREV is the revision prior to the last push."
       (publish ctype))
     (do-subclasses (itype index)
       (publish itype))
-    (update-symlink (format nil "index.~A" (page-ext *config*))
+    (update-symlink (blog-index *config*)
                     (format nil "1.~A" (page-ext *config*)))))
 
 (defgeneric deploy (staging)

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -30,6 +30,13 @@
    :staging-dir  "/tmp/coleslaw"
    :blog-index   "index.html"))
 
+(defmethod initialize-instance :after ((config blog) &key)
+  (with-slots (routing) config
+    (setf routing
+          (map 'list
+               #'(lambda (el) (list (first el) (eval (second el))))
+               routing))))
+
 (defun dir-slot-reader (config name)
   "Take CONFIG and NAME, and return a directory pathname for the matching SLOT."
   (ensure-directory-pathname (slot-value config name)))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -16,7 +16,8 @@
    (sitenav         :initarg :sitenav        :reader sitenav)
    (staging-dir     :initarg :staging-dir    :reader staging-dir)
    (theme           :initarg :theme          :reader theme)
-   (title           :initarg :title          :reader title))
+   (title           :initarg :title          :reader title)
+   (blog-index      :initarg :blog-index     :reader blog-index))
   (:default-initargs
    :feeds        nil
    :license      nil
@@ -26,7 +27,8 @@
    :lang         "en"
    :page-ext     "html"
    :separator    ";;;;;"
-   :staging-dir  "/tmp/coleslaw"))
+   :staging-dir  "/tmp/coleslaw"
+   :blog-index   "index.html"))
 
 (defun dir-slot-reader (config name)
   "Take CONFIG and NAME, and return a directory pathname for the matching SLOT."

--- a/src/content.lisp
+++ b/src/content.lisp
@@ -49,9 +49,9 @@
 
 (defclass content ()
   ((url  :initarg :url  :reader page-url)
-   (date :initarg :date :reader content-date)
+   (date :initarg :date :reader date-of)
    (file :initarg :file :reader content-file)
-   (tags :initarg :tags :reader content-tags)
+   (tags :initarg :tags :reader tags-of)
    (text :initarg :text :reader content-text))
   (:default-initargs :tags nil :date nil))
 
@@ -95,15 +95,15 @@
 (defun tag-p (tag obj)
   "Test if OBJ is tagged with TAG."
   (let ((tag (if (typep tag 'tag) tag (make-tag tag))))
-    (member tag (content-tags obj) :test #'tag-slug=)))
+    (member tag (tags-of obj) :test #'tag-slug=)))
 
 (defun month-p (month obj)
   "Test if OBJ was written in MONTH."
-  (search month (content-date obj)))
+  (search month (date-of obj)))
 
 (defun by-date (content)
   "Sort CONTENT in reverse chronological order."
-  (sort content #'string> :key #'content-date))
+  (sort content #'string> :key #'date-of))
 
 (defun find-content-by-path (path)
   "Find the CONTENT corresponding to the file at PATH."

--- a/src/documents.lisp
+++ b/src/documents.lisp
@@ -40,7 +40,9 @@ is provided, it overrides the route used."
          (route (get-route class-name)))
     (unless route
       (error "No routing method found for: ~A" class-name))
-    (let* ((result (format nil route unique-id))
+    (let* ((result (if (typep route 'function)
+                       (funcall route document)
+                       (format nil route unique-id)))
            (type (or (pathname-type result) (page-ext *config*))))
       (make-pathname :type type :defaults result))))
 

--- a/src/indexes.lisp
+++ b/src/indexes.lisp
@@ -92,12 +92,12 @@ of content loaded in the DB."
 
 (defun all-months ()
   "Retrieve a list of all months with published content."
-  (let ((months (mapcar (lambda (x) (subseq (content-date x) 0 7))
+  (let ((months (mapcar (lambda (x) (subseq (date-of x) 0 7))
                         (find-all 'post))))
     (sort (remove-duplicates months :test #'string=) #'string>)))
 
 (defun all-tags ()
   "Retrieve a list of all tags used in content."
-  (let* ((dupes (mappend #'content-tags (find-all 'post)))
+  (let* ((dupes (mappend #'tags-of (find-all 'post)))
          (tags (remove-duplicates dupes :test #'tag-slug=)))
     (sort tags #'string< :key #'tag-name)))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -21,6 +21,9 @@
            #:title-of
            #:author-of
            #:find-content-by-path
+           #:date-of
+           #:tags-of
+           #:slugify
            ;; Theming + Plugin API
            #:theme-fn
            #:plugin-conf-error

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -95,6 +95,12 @@ along with any missing parent directories otherwise."
                    :external-format :utf-8)
     (write text :stream out :escape nil)))
 
+(defun get-first-numeric-index ()
+  "Return the relative path of the first numeric index file"
+  (page-url (find-if (lambda (x)
+                       (eql (index-name x) 1))
+                     (find-all 'numeric-index))))
+
 (defun get-updated-files (&optional (revision *last-revision*))
   "Return a plist of (file-status file-name) for files that were changed
 in the git repo since REVISION."


### PR DESCRIPTION
Here's a bunch of improvements to content routing that I find useful.

**1. Blog index**

I want my index.html to be a static page and, if I do so now, the first page of the numeric index gets overwritten. This is because coleslaw creates a symlink from index.html to the first page of the numeric index. This change allows you to specify a custom name or `nil` for the blog index.

**2. Point the blog index to the first page of the numeric index irrespective of the routing settings**

This fixes the bug where the code assumes that the first page of the numeric index is always called `1.html`. However, this may not be be true, depending the routing settings.

**3. Allow for lambdas in routing settings**

I really like having something like this:

```lisp
 :routing ((:post           (lambda (document)
                              (format nil "posts/~a-~a"
                                      (subseq (coleslaw:date-of document) 0 7)
                                      (coleslaw:slugify (coleslaw:title-of document)))))
           (:tag-index      "tag/~a")
           (:month-index    "date/~a")
           (:numeric-index  "post-index-~d")
           (:feed           "~a.xml")
           (:tag-feed       "tag/~a.xml"))
```