### PR TITLE
Allow plug-ins to be defined in the user repo

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -49,7 +49,9 @@
 (defun enable-plugin (name args)
   "Given a plugin, NAME, compile+load it and call its ENABLE function with ARGS."
   (flet ((plugin-path (sym)
-           (app-path "plugins/~(~A~)" sym))
+           (if (probe-file (repo-path "plugins/~(~A~).lisp" sym))
+               (repo-path "plugins/~(~A~)" sym)
+               (app-path "plugins/~(~A~)" sym)))
          (plugin-package (sym)
            (format nil "~:@(coleslaw-~A~)" sym)))
     (let ((file (plugin-path name)))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -13,6 +13,14 @@
   (:export #:main
            #:preview
            #:*config*
+           ;; Config Accessors
+           #:author
+           #:deploy-dir
+           #:domain
+           #:page-ext
+           #:repo-dir
+           #:staging-dir
+           #:title
            ;; Core Classes
            #:content
            #:post


### PR DESCRIPTION
It's useful to have the ability to define plug-ins in the user repo, because some of them are inherently site-specific. Ie. I use a plug-in to change the way how 3bmd renders images:

```
![Some description]({$config.domain}/static/images/img_0001_some_image.png)
```
is rendered as:
```
"<div class=\"img-wrapper\">"
"  <div class=\"img\">"
"    <img src=\"~a\" ~@[alt=\"~a\"~]/>"
"    <div class=\"img-caption\">~@[~a~]</div>"
"  </div>"
"</div>"
```
instead of the default:
```
"<img src=\"~a\" ~@[alt=\"~a\"~] ~@[title=\"~a\"~]/>
```

You can also use user plug-ing to tweak various things that are tweakable only in lisp.