### PR TITLE
themes: add relative tag support for sitenav url

### DIFF
--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -20,7 +20,11 @@
     <div class="navigation">
       <a href="{$config.domain}">{$config.title}</a> |
       {foreach $link in $config.sitenav}
-        <a href="{$link.url}">{$link.name}</a>
+        {if $link.relative}
+          <a href="{$config.domain}/{$link.url}">{$link.name}</a>
+        {else}
+          <a href="{$link.url}">{$link.name}</a>
+        {/if}
         {if not isLast($link)} {sp}|{sp} {/if}
       {/foreach}
     </div>

--- a/themes/readable/base.tmpl
+++ b/themes/readable/base.tmpl
@@ -26,7 +26,13 @@
                 <a class="brand" href="{$config.domain}">{$config.title}</a>
                 <ul class="nav">
                   {foreach $link in $config.sitenav}
-                    <li><a href="{$link.url}">{$link.name}</a></li>
+                  <li>
+                    {if $link.relative}
+                      <a href="{$config.domain}/{$link.url}">{$link.name}</a>
+                    {else}
+                      <a href="{$link.url}">{$link.name}</a>
+                    {/if}
+                  </li>
                   {/foreach}
                 </ul>
               </div>


### PR DESCRIPTION
This allows us providing not fully qualified url but to attach it to our
domain. This is helpful for static-pages when we navigate from inside a
post (which is nested deeper, like www.turtleware.eu/posts/xxx.html).