### PR TITLE
 #104 - mobile CSS updates for hyde

### DIFF
--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -6,6 +6,7 @@
   <head>
     <title>{$config.title}</title>
     <meta http-equiv="content-type" content="text/html; charset={$config.charset}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="//fonts.googleapis.com/css?family=Vollkorn:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css" />
     <link href="//fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
     <link href= "{$config.domain}/css/style.css" rel="stylesheet" type="text/css" />

--- a/themes/hyde/css/style.css
+++ b/themes/hyde/css/style.css
@@ -47,3 +47,54 @@ span.paren5 { background-color : inherit; -webkit-transition: background-color 0
 span.paren5:hover { color : inherit; background-color : #CAFFCA; }
 span.paren6 { background-color : inherit; -webkit-transition: background-color 0.2s linear; }
 span.paren6:hover { color : inherit; background-color : #FFBAFF; }
+
+@media (max-width: 680px) {
+
+    #content {
+        padding-top: 0em
+    }
+
+    .title {
+        margin-left: 0.1em;
+    }
+
+    .article-meta {
+        margin-bottom: 1em;
+    }
+
+    .article-meta, .article-content {
+        float: left;
+        margin-left: 0em;
+        margin-right: 0em;
+        width: 90%;
+        padding-left: 5%;
+    }
+
+    .article, .article-content {
+        margin-left: 0em;
+        text-align: justify;
+    }
+
+    img {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+        width: 100%;
+    }
+
+    #coleslaw-logo {
+        float: none;
+    }
+
+    #coleslaw-logo img {
+        margin-left: auto;
+        margin-right: auto;
+        float: none;
+        width: auto;
+    }
+
+    .fineprint a img {
+        width: auto;
+        clear: both;
+    }
+}


### PR DESCRIPTION
Issue #104 

Firefox mobile did not even attempt to render the site as mobile and you would have to zoom in to read anything. Fixed with meta tag in first commit.

Afterwards, some CSS to try to:
- clean up the margin
- justify the font of the main body
-  default images to center of page, full width
- fix footnote

[Some images of before/after.](https://imgur.com/a/cIugB) They kinda got jumbled around, the ones with 3 tabs open are before shots.

Tested on Firefox and Chrome mobile on a Motorola E and Chrome/Firefox devtools. Changes should affect phones up until about an iPhone 6 Plus. 


Wasn't sure how far to go with some of the stuff like image tag css, and I am by no means a CSS expert, so feel free to give opinions/suggestions. 
