### PR TITLE
Move coleslaw-conf to its own ASDF system

### DIFF
--- a/coleslaw-conf.asd
+++ b/coleslaw-conf.asd
@@ -1,0 +1,12 @@
+(in-package #:asdf-user)
+
+(defsystem #:coleslaw-conf
+  :name "coleslaw-conf"
+  :description "Configuration variable for Coleslaw, Flexible Lisp Blogware"
+  :version "0.9.7"
+  :license "BSD"
+  :author "Brit Butler <redline6561@gmail.com>"
+  :pathname "src/"
+  :depends-on ()
+  :serial t
+  :components ((:file "coleslaw-conf")))

--- a/coleslaw-test.asd
+++ b/coleslaw-test.asd
@@ -1,0 +1,13 @@
+(in-package #:asdf-user)
+
+(defsystem #:coleslaw-test
+  :description "A test suite for coleslaw."
+  :license "BSD"
+  :author "Brit Butler <redline6561@gmail.com>"
+  :depends-on (:coleslaw :prove)
+  :defsystem-depends-on (:prove-asdf)
+  :components ((:module "tests"
+                :components
+                        ((:test-file "tests"))))
+  :perform (test-op :after (op c)
+                    (uiop:symbol-call :prove 'run c)))

--- a/coleslaw.asd
+++ b/coleslaw.asd
@@ -1,3 +1,5 @@
+(in-package #:asdf-user)
+
 (defsystem #:coleslaw
   :name "coleslaw"
   :description "Flexible Lisp Blogware"
@@ -5,7 +7,8 @@
   :license "BSD"
   :author "Brit Butler <redline6561@gmail.com>"
   :pathname "src/"
-  :depends-on (:closure-template
+  :depends-on (:coleslaw-conf
+               :closure-template
                :3bmd
                :3bmd-ext-code-blocks
                :alexandria
@@ -28,18 +31,6 @@
                (:file "coleslaw"))
   :in-order-to ((test-op (test-op coleslaw-test))))
 
-(defsystem #:coleslaw-test
-  :description "A test suite for coleslaw."
-  :license "BSD"
-  :author "Brit Butler <redline6561@gmail.com>"
-  :depends-on (:coleslaw :prove)
-  :defsystem-depends-on (:prove-asdf)
-  :components ((:module "tests"
-                :components
-                        ((:test-file "tests"))))
-  :perform (test-op :after (op c)
-                    (uiop:symbol-call :prove 'run c)))
-
-(defpackage #:coleslaw-conf (:export #:*basedir*))
-(defparameter coleslaw-conf:*basedir*
-  (make-pathname :name nil :type nil :defaults *load-truename*))
+(defmethod perform :before ((op load-op)
+                            (system (eql (find-system :coleslaw))))
+  (uiop:symbol-call "COLESLAW-CONF" 'set-basedir #.*load-truename*))

--- a/src/coleslaw-conf.lisp
+++ b/src/coleslaw-conf.lisp
@@ -1,0 +1,12 @@
+(defpackage #:coleslaw-conf
+  (:use #:cl)
+  (:export #:*basedir*
+           #:set-basedir))
+
+(in-package #:coleslaw-conf)
+
+(defvar *basedir*)
+
+(defun set-basedir (pathname)
+  (setf coleslaw-conf:*basedir*
+    (make-pathname :name nil :type nil :defaults pathname)))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -3,9 +3,10 @@
 
 (in-package :coleslaw-tests)
 
-(plan nil)
+(plan 1)
 
-(deftest 1-is-a-number
-  (is-type 1 'fixnum))
+(diag "COLESLAW-CONF:*BASEDIR* points to Coleslaw's top level directory")
+(is (car (last (pathname-directory coleslaw-conf:*basedir*)))
+    "coleslaw" :test #'string=)
 
 (finalize)


### PR DESCRIPTION
Ideally the package coleslaw would only have symbols that refer to
configuration variables. However to ease setting *BASEDIR* to the right
value using UIOP:SYMBOL-CALL we provide a setter, SET-BASEDIR. Btw, the previous code had an implementation defined use list.

- Split each ASDF system into its own file

- All system definitions are made in the ASDF-USER package, as
recommended by ASDF.

Fixes #110