### PR TITLE
Improve COLESLAW-CONF:*BASEDIR* tests

### DIFF
--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -3,10 +3,14 @@
 
 (in-package :coleslaw-tests)
 
-(plan 1)
+(plan 3)
 
 (diag "COLESLAW-CONF:*BASEDIR* points to Coleslaw's top level directory")
 (is (car (last (pathname-directory coleslaw-conf:*basedir*)))
     "coleslaw" :test #'string=)
+(ok (probe-file (merge-pathnames #P"plugins" coleslaw-conf:*basedir*))
+    "COLESLAW-CONF:*BASEDIR* has a plugins sub-directory")
+(ok (probe-file (merge-pathnames #P"themes" coleslaw-conf:*basedir*))
+    "COLESLAW-CONF:*BASEDIR* has a themes sub-directory")
 
 (finalize)


### PR DESCRIPTION
Check for the presence of plugins and themes sub-directories. This is to
ensure that COLESLAW-CONF:*BASEDIR* is not bound the directory of the
FASL cache.