### PR TITLE
Ignore Linux CCL FASL files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *~
 *.fasl
-*.dx??fsl
+*.dx32fsl
+*.dx64fsl
+*.lx32fsl
+*.lx64fsl
 ignore/
 generated/
 .curr


### PR DESCRIPTION
CCL has different prefixes for different platforms[0].

[0]: http://ccl.clozure.com/manual/chapter3.1.html