### PR TITLE
Add 3bmd youtube plugin

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -202,3 +202,14 @@ CL-USER> (chirp:complete-authentication "4173325")
                       :output "/home/redlinernotes/blog/")`
 
 [config_file]: http://github.com/redline6561/coleslaw/blob/master/examples/example.coleslawrc
+
+
+## Markdown Embeding youtube Youtube
+
+**Description**: Embed youtube videos in markdown using the shorthand syntax
+`!yt[<video-id>(|options*)*]`.  Options can be *width*, *height* or any of the
+[player parameters](https://developers.google.com/youtube/player_parameters).
+
+For example `!yt[oeul8fTG9dM|width=480,allowfullscreen]`.
+
+**Example**: `(3bmd-youtube)`

--- a/plugins/3bmd-youtube.lisp
+++ b/plugins/3bmd-youtube.lisp
@@ -1,0 +1,12 @@
+(eval-when (:compile-toplevel :load-toplevel)
+  (ql:quickload :3bmd-youtube))
+
+(defpackage #:coleslaw-3bmd-youtube
+  (:use #:cl)
+  (:export
+   #:enable))
+
+(in-package #:coleslaw-3bmd-youtube)
+
+(defun enable ()
+  (setf 3bmd-youtube:*youtube-embeds* t))


### PR DESCRIPTION
This plugin allows users to use a shorthand syntax to embed youtube
videos in markdown

Closes #124