### PR TITLE
Add support for excerpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ title: foo
 tags: bar, baz
 date: yyyy-mm-dd hh:mm:ss
 format: html (for raw html) or md (for markdown)
+excerpt: Can also be extracted from content (see :excerpt-sep config param)
 ;;;;;
 your post
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ It is usually recommend to start from the [example config][ex_config] and pare d
 There are also many *optional* config parameters such as:
 * `:charset`       => to set HTML attributes for international characters, default: "UTF-8"
 * `:feeds`         => to generate RSS and Atom feeds for certain tagged content
+* `:excerpt-sep`   => to set the separator for excerpt in content, default: `<!--more-->`
 * `:lang`          => to set HTML attributes indicating the site language, default: "en"
 * `:license`       => to override the displayed content license, the default is CC-BY-SA
 * `:page-ext`      => to set the suffix of generated files, default: "html"

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -167,6 +167,7 @@ The variable that should be available to all templates is:
    - `date`, the date of posting
    - `text`, the HTML of the post's body
    - `title`, the title of the post
+   - `excerpt`, the excerpt of the post, same as `text` by default
 
 ### Step 4. Include the content
 
@@ -193,7 +194,7 @@ A simple `index.tmpl` looks like this:
 {template index}
 {foreach $obj in $index.content}
 <h1>{$object.title}</h1>
-  {$object.text |noAutoescape}
+  {$object.excerpt |noAutoescape}
 {/foreach}
 {/template}
 ```

--- a/examples/example.coleslawrc
+++ b/examples/example.coleslawrc
@@ -1,6 +1,7 @@
 (:author "Brit Butler"
  :deploy-dir "/home/git/blog/"
  :domain "http://blog.redlinernotes.com"
+ :excerpt-sep "<!--more-->"
  :feeds ("lisp")
  :plugins ((analytics :tracking-code "foo")
            (disqus :shortname "my-site-name")

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -5,6 +5,7 @@
    (charset         :initarg :charset        :reader charset)
    (deploy-dir      :initarg :deploy-dir     :reader deploy-dir)
    (domain          :initarg :domain         :reader domain)
+   (excerpt-sep     :initarg :excerpt-sep    :reader excerpt-sep)
    (feeds           :initarg :feeds          :reader feeds)
    (lang            :initarg :lang           :reader lang)
    (license         :initarg :license        :reader license)
@@ -22,6 +23,7 @@
    :license      nil
    :plugins      nil
    :sitenav      nil
+   :excerpt-sep  "<!--more-->"
    :charset      "UTF-8"
    :lang         "en"
    :page-ext     "html"

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -5,7 +5,7 @@
                             #:make-keyword
                             #:mappend)
   (:import-from :cl-fad #:file-exists-p)
-  (:import-from :cl-ppcre #:scan-to-strings)
+  (:import-from :cl-ppcre #:scan-to-strings #:split)
   (:import-from :closure-template #:compile-template)
   (:import-from :local-time #:format-rfc1123-timestring)
   (:import-from :uiop #:getcwd

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -11,11 +11,11 @@
   (with-slots (url title author excerpt format text) object
     (setf url (compute-url object (slugify title))
           format (make-keyword (string-upcase format))
-          text (render-text text format)
           excerpt (or excerpt
                       (first (split (excerpt-sep *config*)
                                     (render-text text format)
                                     :limit 2)))
+          text (render-text text format)
           author (or author (author *config*)))))
 
 (defmethod render ((object post) &key prev next)

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -3,14 +3,19 @@
 (defclass post (content)
   ((title  :initarg :title  :reader title-of)
    (author :initarg :author :reader author-of)
+   (excerpt :initarg :excerpt :reader excerpt-of)
    (format :initarg :format :reader post-format))
-  (:default-initargs :author nil))
+  (:default-initargs :author nil :excerpt nil))
 
 (defmethod initialize-instance :after ((object post) &key)
-  (with-slots (url title author format text) object
+  (with-slots (url title author excerpt format text) object
     (setf url (compute-url object (slugify title))
           format (make-keyword (string-upcase format))
           text (render-text text format)
+	  excerpt (or excerpt
+		      (first (split (excerpt-sep *config*)
+				    (render-text text format)
+				    :limit 2)))
           author (or author (author *config*)))))
 
 (defmethod render ((object post) &key prev next)

--- a/src/posts.lisp
+++ b/src/posts.lisp
@@ -12,10 +12,10 @@
     (setf url (compute-url object (slugify title))
           format (make-keyword (string-upcase format))
           text (render-text text format)
-	  excerpt (or excerpt
-		      (first (split (excerpt-sep *config*)
-				    (render-text text format)
-				    :limit 2)))
+          excerpt (or excerpt
+                      (first (split (excerpt-sep *config*)
+                                    (render-text text format)
+                                    :limit 2)))
           author (or author (author *config*)))))
 
 (defmethod render ((object post) &key prev next)

--- a/tests/files/127.txt
+++ b/tests/files/127.txt
@@ -3,4 +3,5 @@ title: We should handle CR-LF
 tags: fixtures
 date: 2014-12-16
 format: md
+excerpt: An excerpt
 ;;;;;

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -19,6 +19,6 @@
 (with-open-file (in (asdf:system-relative-pathname :coleslaw-test "tests/files/127.txt"))
   (diag "PARSE-METADATA should handle files with CR-LF line endings.")
   (is (coleslaw::parse-metadata in) '(:TITLE "We should handle CR-LF" :TAGS "fixtures" :DATE "2014-12-16" :FORMAT
- "md") :test 'equalp))
+ "md" :EXCERPT "An excerpt") :test 'equalp))
 
 (finalize)

--- a/themes/hyde/index.tmpl
+++ b/themes/hyde/index.tmpl
@@ -6,7 +6,7 @@
   <div class="article-meta">
     <a class="article-title" href="{$config.domain}/{$obj.url}">{$obj.title}</a>
     <div class="date"> posted on {$obj.date}</div>
-    <div class="article">{$obj.text |noAutoescape}</div>
+    <div class="article">{$obj.excerpt |noAutoescape}</div>
   </div>
 {/foreach}
 <div id="relative-nav">

--- a/themes/readable/index.tmpl
+++ b/themes/readable/index.tmpl
@@ -6,7 +6,7 @@
   <div class="row-fluid">
     <h1><a href="{$config.domain}/{$obj.url}">{$obj.title}</a></h1>
     <p class="date-posted">posted on {$obj.date}</p>
-    {$obj.text |noAutoescape}
+    {$obj.excerpt |noAutoescape}
   </div>
 {/foreach}
 <div id="relative-nav">


### PR DESCRIPTION
Similar to what [Jekyll](http://jekyllrb.com/docs/posts/#post-excerpts) supports. It basically allows to have an excerpt for posts in the index, instead of having the full article. It works in two different ways:

* Automatically extracted from content. With config parameter `:excerpt-sep` a separator is defined (`<!--more-->`) by default. Add the separator in content to marks the end of the excerpt. This is how Jekyll works.
* Manually through `:excerpt` metadata field in a post. If defined this overrides previous method.

Themes' `index.tmpl` is also changed to make use of this excerpt, but it's fully backwards compatible, since the excerpt will by default be just post's text.