### PR TITLE
Get the month from content-date, if exists, instead of whole date.

### DIFF
--- a/src/indexes.lisp
+++ b/src/indexes.lisp
@@ -95,7 +95,8 @@ of content loaded in the DB."
   (let ((months (loop :for post :in (find-all 'post)
                       :for content-date := (content-date post)
                       :when content-date
-                        :collect content-date)))
+                      :collect (subseq content-date 0
+                                       (min 7 (length content-date))))))
     (sort (remove-duplicates months :test #'string=) #'string>)))
 
 (defun all-tags ()


### PR DESCRIPTION
Month parsing was removed in 2ee26090, don't think it was intended though.