### PR TITLE
Mathjax cdn update

### DIFF
--- a/docs/plugin-use.md
+++ b/docs/plugin-use.md
@@ -85,7 +85,7 @@ post with `format: cl-who` and the plugin will do the rest.
   posts.  Default value is `nil`.
 
 - `:location` specifies the location of the `MathJax.js` file.  The
-  default value is `"http://cdn.mathjax.org/mathjax/latest/MathJax.js"`.
+  default value is `"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"`.
   This is useful if you have a local copy of MathJax and want to use that
   version.
 

--- a/plugins/mathjax.lisp
+++ b/plugins/mathjax.lisp
@@ -23,7 +23,7 @@
          (some #'mathjax-p (index-content index)))))
 
 (defun enable (&key force config (preset "TeX-AMS-MML_HTMLorMML")
-                 (location "http://cdn.mathjax.org/mathjax/latest/MathJax.js"))
+                 (location "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"))
   (flet ((inject-p (x)
            (when (or force (mathjax-p x))
              (format nil *mathjax-header* config location preset))))


### PR DESCRIPTION
MathJax's CDN is [shutting down](https://www.mathjax.org/cdn-shutting-down/) I've changed to cdnjs as suggested in the article. Note that:
* Version number must be changed manually (there's no latest anymore.)
* I've changed from HTTP to HTTPS which is I think a safer default.