### PR TITLE
[hyde template] use span + CSS for the sitenav separator

### DIFF
--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -19,14 +19,17 @@
   </head>
   <body>
     <div class="navigation">
-      <a href="{$config.domain}">{$config.title}</a> |
+      <span class="sitenav">
+        <a href="{$config.domain}">{$config.title}</a>
+      </span>
       {foreach $link in $config.sitenav}
+      <span class="sitenav">
         {if $link.relative}
-          <a href="{$config.domain}/{$link.url}">{$link.name}</a>
+        <a href="{$config.domain}/{$link.url}">{$link.name}</a>
         {else}
-          <a href="{$link.url}">{$link.name}</a>
+        <a href="{$link.url}">{$link.name}</a>
         {/if}
-        {if not isLast($link)} {sp}|{sp} {/if}
+      </span>
       {/foreach}
     </div>
     <div id="content">

--- a/themes/hyde/base.tmpl
+++ b/themes/hyde/base.tmpl
@@ -9,8 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="//fonts.googleapis.com/css?family=Vollkorn:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css" />
     <link href="//fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
-    <link href= "{$config.domain}/css/style.css" rel="stylesheet" type="text/css" />
-    <link rel="alternate" href="{$config.domain}/rss.xml" type="application/rss+xml" />
+    <link href= "/css/style.css" rel="stylesheet" type="text/css" />
+    <link rel="alternate" href="/rss.xml" type="application/rss+xml" />
     {if $injections.head}
       {foreach $injection in $injections.head}
         {$injection |noAutoescape}
@@ -20,12 +20,12 @@
   <body>
     <div class="navigation">
       <span class="sitenav">
-        <a href="{$config.domain}">{$config.title}</a>
+        <a href="/">{$config.title}</a>
       </span>
       {foreach $link in $config.sitenav}
       <span class="sitenav">
         {if $link.relative}
-        <a href="{$config.domain}/{$link.url}">{$link.name}</a>
+        <a href="/{$link.url}">{$link.name}</a>
         {else}
         <a href="{$link.url}">{$link.name}</a>
         {/if}
@@ -47,12 +47,12 @@
         {$config.license}
       {else}
         <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/deed.en_US">
-          <img alt="Creative Commons License" style="border-width:0" src="{$config.domain}/css/cc-by-sa.png" />
+          <img alt="Creative Commons License" style="border-width:0" src="/css/cc-by-sa.png" />
         </a>
       {/if}
       by {$config.author}
       <a id="coleslaw-logo" href="https://github.com/redline6561/coleslaw">
-        <img src="{$config.domain}/css/logo_small.jpg" alt="Coleslaw logo" />
+        <img src="/css/logo_small.jpg" alt="Coleslaw logo" />
       </a>
     </div>
   </body>

--- a/themes/hyde/css/style.css
+++ b/themes/hyde/css/style.css
@@ -1,6 +1,7 @@
 #content { background: #fff; padding-top: 1em }
 #header { float: right; margin-left: 1em; margin-bottom: 1em }
 #coleslaw-logo { float: right; }
+span.sitenav:not(:last-child):after { content: '|' }
 a { text-decoration: none; color: #992900 }
 a.anchor { color: black }
 .date { font-style: italic }

--- a/themes/hyde/index.tmpl
+++ b/themes/hyde/index.tmpl
@@ -4,20 +4,20 @@
 <h1 class="title">{$index.title}</h1>
 {foreach $obj in $index.content}
   <div class="article-meta">
-    <a class="article-title" href="{$config.domain}/{$obj.url}">{$obj.title}</a>
+    <a class="article-title" href="/{$obj.url}">{$obj.title}</a>
     <div class="date"> posted on {$obj.date}</div>
     <div class="article">{$obj.excerpt |noAutoescape}</div>
   </div>
 {/foreach}
 <div id="relative-nav">
-  {if $prev} <a href="{$config.domain}/{$prev.url}">Previous</a> {/if}
-  {if $next} <a href="{$config.domain}/{$next.url}">Next</a> {/if}
+  {if $prev} <a href="/{$prev.url}">Previous</a> {/if}
+  {if $next} <a href="/{$next.url}">Next</a> {/if}
 </div>
 {if $tags}
 <div id="tagsoup">
   <p>This blog covers
     {foreach $tag in $tags}
-      <a href="{$config.domain}/{$tag.url}">{$tag.name}</a>{nil}
+      <a href="/{$tag.url}">{$tag.name}</a>{nil}
       {if not isLast($tag)},{sp}{/if}
     {/foreach}
 </div>
@@ -26,7 +26,7 @@
 <div id="monthsoup">
   <p>View content from
     {foreach $month in $months}
-      <a href="{$config.domain}/{$month.url}">{$month.name}</a>{nil}
+      <a href="/{$month.url}">{$month.name}</a>{nil}
       {if not isLast($month)},{sp}{/if}
     {/foreach}
 </div>

--- a/themes/hyde/post.tmpl
+++ b/themes/hyde/post.tmpl
@@ -6,7 +6,7 @@
   <div class="tags">{\n}
     {if $post.tags}
       Tagged as {foreach $tag in $post.tags}
-        <a href="{$config.domain}/{$tag.url}">{$tag.name}</a>{nil}
+        <a href="/{$tag.url}">{$tag.name}</a>{nil}
           {if not isLast($tag)},{sp}{/if}
       {/foreach}
     {/if}
@@ -21,7 +21,7 @@
   {$post.text |noAutoescape}
 </div>{\n}
 <div class="relative-nav">{\n}
-  {if $prev} <a href="{$config.domain}/{$prev.url}">Previous</a><br> {/if}{\n}
-  {if $next} <a href="{$config.domain}/{$next.url}">Next</a><br> {/if}{\n}
+  {if $prev} <a href="/{$prev.url}">Previous</a><br> {/if}{\n}
+  {if $next} <a href="/{$next.url}">Next</a><br> {/if}{\n}
 </div>{\n}
 {/template}


### PR DESCRIPTION
In a theme `hyde`, content separators are hard-coded. This can be replaced with a CSS.